### PR TITLE
"Comment out unused imports for orders module.

### DIFF
--- a/src/apps/transports/models/__init__.py
+++ b/src/apps/transports/models/__init__.py
@@ -1,2 +1,2 @@
-from apps.transports.models.orders import *
+# from apps.transports.models.orders import *
 from apps.transports.models.transport import *

--- a/src/apps/transports/serializers/__init__.py
+++ b/src/apps/transports/serializers/__init__.py
@@ -1,2 +1,2 @@
-from apps.transports.serializers.orders import *
+# from apps.transports.serializers.orders import *
 from apps.transports.serializers.transport import *


### PR DESCRIPTION
The imports for the `orders` module in serializers and models were commented out as they are currently unused. This helps in improving clarity and avoiding potential confusion or unnecessary dependencies."