### PR TITLE
Update token lifetime for production environment

### DIFF
--- a/src/config/settings/simplejwt.py
+++ b/src/config/settings/simplejwt.py
@@ -2,8 +2,7 @@ from datetime import timedelta
 
 from django.conf import settings
 
-
-ACCESS_TOKEN_LIFETIME = timedelta(days=1) if settings.ENV == 'development' else timedelta(minutes=10)
+ACCESS_TOKEN_LIFETIME = timedelta(days=1) if settings.ENV == 'development' else timedelta(days=1)
 REFRESH_TOKEN_LIFETIME = timedelta(days=2) if settings.ENV == 'development' else timedelta(days=1)
 
 SIMPLE_JWT = {


### PR DESCRIPTION
Updated the `ACCESS_TOKEN_LIFETIME` for the production environment to ensure consistency with the development environment. The token lifetime is now extended from 10 minutes to 1 day, improving usability for production. Refresh token lifetimes remain